### PR TITLE
Delete SBOM

### DIFF
--- a/client/src/app/pages/sbom-list/sbom-list.tsx
+++ b/client/src/app/pages/sbom-list/sbom-list.tsx
@@ -55,7 +55,7 @@ import {
 import { useDownload } from "@app/hooks/useDownload";
 import { useSelectionState } from "@app/hooks/useSelectionState";
 import {
-  useDeleteSBOMByIdMutation,
+  useDeleteSBOMMutation,
   useFetchSBOMs,
   useUpdateSbomLabelsMutation,
   useUploadSBOM,
@@ -105,7 +105,7 @@ export const SbomList: React.FC = () => {
     });
   };
 
-  const { mutate: deleteSbom } = useDeleteSBOMByIdMutation(
+  const { mutate: deleteSbom } = useDeleteSBOMMutation(
     onDeleteSbomSuccess,
     onDeleteSbomError
   );

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -3,17 +3,15 @@ import { AxiosError } from "axios";
 
 import { HubRequestParams, SBOM } from "@app/api/models";
 import {
+  deleteSBOMById,
   getSBOMById,
   getSBOMSourceById,
   getSBOMs,
   getSBOMsByPackageId,
   updateSbomLabels,
   uploadSbom,
-  deleteSBOMById,
 } from "@app/api/rest";
 import { useUpload } from "@app/hooks/useUpload";
-import {NotificationsContext} from "@app/components/NotificationsContext";
-import React from "react";
 
 export const SBOMsQueryKey = "sboms";
 
@@ -53,21 +51,18 @@ export const useFetchSBOMById = (id?: number | string) => {
   };
 };
 
-export const useDeleteSBOMByIdMutation = () => {
+export const useDeleteSBOMByIdMutation = (
+  onSuccess: (sbom: SBOM) => void,
+  onError: (err: AxiosError, sbom: SBOM) => void
+) => {
   const queryClient = useQueryClient();
-  const {pushNotification} = React.useContext(NotificationsContext);
-
   return useMutation({
-    mutationFn: (id: number | string) => deleteSBOMById(id),
-    onSuccess: (_res, id) => {
-      queryClient.invalidateQueries({queryKey: [SBOMsQueryKey, id]});
+    mutationFn: (sbom: SBOM) => deleteSBOMById(sbom.id),
+    onSuccess: (_res, sbom) => {
+      onSuccess(sbom);
+      queryClient.invalidateQueries({ queryKey: [SBOMsQueryKey] });
     },
-    onError: (err: AxiosError, _payload: number | string) => {
-      pushNotification({
-        title: "Error while deleting SBOM",
-        variant: "danger",
-      });
-    }
+    onError,
   });
 };
 

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -51,7 +51,7 @@ export const useFetchSBOMById = (id?: number | string) => {
   };
 };
 
-export const useDeleteSBOMByIdMutation = (
+export const useDeleteSBOMMutation = (
   onSuccess: (sbom: SBOM) => void,
   onError: (err: AxiosError, sbom: SBOM) => void
 ) => {


### PR DESCRIPTION
- Add confirmation dialog. Note that the name of the SBOM being delete is part of the title of the dialog

![image](https://github.com/user-attachments/assets/c24a446d-2c76-4d7c-a1f4-24b2d2ddb727)

- Add a success & error notification. Note that the SBOM name is part of the notifications. this gives the user context about what he has done (which sbom he deleted).

![image](https://github.com/user-attachments/assets/ae42ef7c-4883-4191-9a04-78990205d1f7)


![image](https://github.com/user-attachments/assets/785850aa-7717-4280-b80d-8a9e46a0bb1c)

- Separate the Notifications from the Query Mutation definition.